### PR TITLE
fix: cannot parse binance ws endopint like wss://dstream.binance.com/…

### DIFF
--- a/crypto-ws-client/src/common/connect_async.rs
+++ b/crypto-ws-client/src/common/connect_async.rs
@@ -39,7 +39,7 @@ pub async fn connect_async(
         let proxy_stream = Socks5Stream::connect(
             proxy_addr.to_string(),
             connect_url.host_str().unwrap().to_string(),
-            connect_url.port().unwrap(),
+            connect_url.port_or_known_default().unwrap(),
             Config::default(),
         )
         .await


### PR DESCRIPTION
```
let url = Url::parse("wss://dstream.binance.com/stream").unwrap();
assert!(url.port() == None);
```

Binance endpoint cannot be parsed, it should use `port_or_known_default` to set default port value.